### PR TITLE
Add new category: XAML Controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Contributions are welcome - any kind of library/software/resource is accepted. T
 
 ## XAML Controls
 * [ExpanderUWP](https://github.com/deanchalk/ExpanderUWP) - Expander Control for Microsoft UWP
+* [PullToRefreshXaml](https://github.com/JustinXinLiu/PullToRefreshUWP_WindowsComposition) - Pull to refresh with the new Windows Composition API.
 
 # Other Awesome Lists
 Other amazingly awesome lists can be found in the [awesome-awesomeness](https://github.com/bayandin/awesome-awesomeness) list.

--- a/README.md
+++ b/README.md
@@ -39,5 +39,7 @@ Contributions are welcome - any kind of library/software/resource is accepted. T
 * [WindowsStateTriggers](https://github.com/dotMorten/WindowsStateTriggers) - WindowsStateTriggers is a collection of custom visual state triggers, including triggers such as DeviceFamilyStateTrigger, NetworkConnectionStateTrigger, RegexStateTrigger and more.
 * [UWP Helpers](https://github.com/LanceMcCarthy/UwpProjects) - A set of custom (e.g. BusyIndicators) and improved (e.g. AdaptiveGridView, NetworkImage) UI controls and specific-function utilities (e.g. IncrementalLoadingCollection) for building UWP apps.
 
+## XAML Controls
+
 # Other Awesome Lists
 Other amazingly awesome lists can be found in the [awesome-awesomeness](https://github.com/bayandin/awesome-awesomeness) list.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Contributions are welcome - any kind of library/software/resource is accepted. T
 * [UWP Helpers](https://github.com/LanceMcCarthy/UwpProjects) - A set of custom (e.g. BusyIndicators) and improved (e.g. AdaptiveGridView, NetworkImage) UI controls and specific-function utilities (e.g. IncrementalLoadingCollection) for building UWP apps.
 
 ## XAML Controls
+* [ExpanderUWP](https://github.com/deanchalk/ExpanderUWP) - Expander Control for Microsoft UWP
 
 # Other Awesome Lists
 Other amazingly awesome lists can be found in the [awesome-awesomeness](https://github.com/bayandin/awesome-awesomeness) list.


### PR DESCRIPTION
The resources in this suggested category aren't full libraries, but rather single controls. I don't think they belong under UI Libraries as they are not a collection of multiple features/services/controls.

Added resources:
- ExpanderUWP
- PullToRefreshXaml
